### PR TITLE
Use the GitHub token if provided

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ author: "Shin'ya Ueoka"
 inputs:
   geckodriver-version:
     description: 'The Geckodriver version to install and use. Examples: 0.28.0, latest.'
+  token:
+    description: 'The GitHub token to use for requests to the GitHub API. Allows a higher rate limit.'
 
 runs:
   using: 'node12'

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,11 @@ type GitHubReleaseApiResponse = {
 const getLatestVersion = async (): Promise<string> => {
   const apiURL = `https://api.github.com/repos/mozilla/geckodriver/releases/latest`;
   const http = new httpm.HttpClient("setup-geckodrive");
-  const resp = await http.getJson<GitHubReleaseApiResponse>(apiURL);
+  const additionalHeaders = {};
+  if (core.getInput("geckodriver-version")) {
+    additionalHeaders[httpm.Headers.Authorization] = 'Bearer ' + core.getInput("token"); 
+  }
+  const resp = await http.getJson<GitHubReleaseApiResponse>(apiURL, additionalHeaders);
   if (resp.statusCode !== httpm.HttpCodes.OK) {
     throw new Error(
       `Failed to get latest version: server returns ${resp.statusCode}`


### PR DESCRIPTION
Fixes #7, presumably fixes #6 (error is inconclusive, but `403` is returned by GitHub whenever the rate limit is hit).

This enables a user to provide a GitHub token using the `token` input. Since rate limits are per-IP, this will also prevent users from hitting the rate limit if they're using a GitHub-provided runner (as runners may appear under the same IP address), even if they only use this action once.