### PR TITLE
Use a GitHub token if provided

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,11 @@ jobs:
       - uses: ./dist/
         with:
           geckodriver-version: "0.26.0"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: geckodriver --version
       - uses: ./dist/
+        with: 
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: geckodriver --version
 
   deploy:
@@ -89,6 +92,9 @@ jobs:
       - uses: browser-actions/setup-geckodriver@latest
         with:
           geckodriver-version: "0.26.0"
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: geckodriver --version
       - uses: browser-actions/setup-geckodriver@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: geckodriver --version

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This action sets by Geckodriver for use in actions by:
 
 ## Usage
 
-See [action.yml](action.yml)
+Valid inputs:
+* `geckodriver-version`: Specific version of geckodriver to use.
+* `token`: GitHub access token. Used to avoid rate limits.
 
 Basic usage:
 
@@ -16,6 +18,8 @@ Basic usage:
 steps:
   - uses: browser-actions/setup-geckodriver@latest
   - run: geckodriver --version
+    with:
+      token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ author: "Shin'ya Ueoka"
 inputs:
   geckodriver-version:
     description: 'The Geckodriver version to install and use. Examples: 0.28.0, latest.'
+  token:
+    description: 'The GitHub token to use for requests to the GitHub API. Allows a higher rate limit.'
 
 runs:
   using: 'node12'

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,13 @@ type GitHubReleaseApiResponse = {
 };
 
 const getLatestVersion = async (): Promise<string> => {
-  const apiURL = `https://api.github.com/repos/mozilla/geckodriver/releases/latest`;
+  const apiURL = "https://api.github.com/repos/mozilla/geckodriver/releases/latest";
   const http = new httpm.HttpClient("setup-geckodrive");
-  const resp = await http.getJson<GitHubReleaseApiResponse>(apiURL);
+  const additionalHeaders: Record<string, any> = {};
+  if (core.getInput("token")) {
+    additionalHeaders["authorization"] = "Bearer " + core.getInput("token");
+  }
+  const resp = await http.getJson<GitHubReleaseApiResponse>(apiURL, additionalHeaders);
   if (resp.statusCode !== httpm.HttpCodes.OK) {
     throw new Error(
       `Failed to get latest version: server returns ${resp.statusCode}`


### PR DESCRIPTION
Fixes https://github.com/browser-actions/setup-geckodriver/issues/7, presumably fixes https://github.com/browser-actions/setup-geckodriver/issues/6 (error is inconclusive, but 403 is returned by GitHub whenever the rate limit is hit).

This enables a user to provide a GitHub token using the token input. This avoids hitting GitHub rate limits, especially for the Windows and macOS runners, by allowing the user to pass the runner GitHub token, authorizing requests and allowing a much higher rate limit. Since rate limits are per-IP, this will also prevent users from hitting the rate limit if they're using a GitHub-provided runner (as runners may appear under the same IP address), even if they only use this action once (the intermittent failure issue).

Supersedes #9, as a force-push was made.