### PR TITLE
Run on node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'The Geckodriver version to install and use. Examples: 0.28.0, latest.'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
avoids deprecation warning.

This will be the behavior shortly when node12 is requested, anyway.

closes #8 