### PR TITLE
Fix: use token on the setup-geckodriver action, not run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Basic usage:
 ```yaml
 steps:
   - uses: browser-actions/setup-geckodriver@latest
-  - run: geckodriver --version
     with:
       token: ${{ secrets.GITHUB_TOKEN }}
+  - run: geckodriver --version
 ```
 
 ## License


### PR DESCRIPTION
The token should apply to the action.