### PR TITLE
chore: prefix on the commit message by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
Add `chore(deps)` prefix on commit message by dependabot.  This prefix is based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) in order to manage versions automatically.