### PR TITLE
fix: support Node 20 and macOS Apple silicon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       # Test built action itself
       - uses: ./dist/
         with:
-          geckodriver-version: "0.26.0"
+          geckodriver-version: "0.35.0"
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: geckodriver --version
       - uses: ./dist/
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: browser-actions/setup-geckodriver@latest
         with:
-          geckodriver-version: "0.26.0"
+          geckodriver-version: "0.35.0"
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: geckodriver --version
       - uses: browser-actions/setup-geckodriver@latest

--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'The GitHub token to use for requests to the GitHub API. Allows a higher rate limit.'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^14.14.16",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@vercel/ncc": "^0.26.1",
+    "@vercel/ncc": "^0.38.3",
     "eslint": "^7.16.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-jest": "^24.1.3",

--- a/src/Installer.ts
+++ b/src/Installer.ts
@@ -42,6 +42,8 @@ export class MacOSInstaller implements Installer {
     switch (platform.arch) {
       case Arch.AMD64:
         return `https://github.com/mozilla/geckodriver/releases/download/v${version}/geckodriver-v${version}-macos.tar.gz`;
+      case Arch.ARM64:
+        return `https://github.com/mozilla/geckodriver/releases/download/v${version}/geckodriver-v${version}-macos-aarch64.tar.gz`;
     }
     throw new UnsupportedPlatformError(platform, version);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,10 +760,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vercel/ncc@^0.26.1":
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.26.1.tgz#457f13c8f207f5e74d19944b6797f4708c02359f"
-  integrity sha512-iVhYAL/rpHgjO88GkDHNVNrp7WTfMFBbeWXNgwaDPMv5rDI4hNOAM0u+Zhtbs42XBQE6EccNaY6UDb/tm1+dhg==
+"@vercel/ncc@^0.38.3":
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.38.3.tgz#5475eeee3ac0f1a439f237596911525a490a88b5"
+  integrity sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==
 
 abab@^2.0.3:
   version "2.0.5"


### PR DESCRIPTION
Node 16 in the GitHub Actions is no longer supported and it migrate to Node 20. This PR also includes Apple silicon (macOS aarch64) support.

close #25 