### PR TITLE
Add support for Linux aarch64 (ARM) builds

### DIFF
--- a/src/Installer.ts
+++ b/src/Installer.ts
@@ -28,6 +28,8 @@ export class LinuxInstaller implements Installer {
         return `https://github.com/mozilla/geckodriver/releases/download/v${version}/geckodriver-v${version}-linux32.tar.gz`;
       case Arch.AMD64:
         return `https://github.com/mozilla/geckodriver/releases/download/v${version}/geckodriver-v${version}-linux64.tar.gz`;
+      case Arch.ARM64:
+        return `https://github.com/mozilla/geckodriver/releases/download/v${version}/geckodriver-v${version}-linux-aarch64.tar.gz`;
     }
     throw new UnsupportedPlatformError(platform, version);
   }


### PR DESCRIPTION
Recent versions of geckodriver have builds for linux-aarch64 (ARM).

For example:

https://github.com/mozilla/geckodriver/releases/tag/v0.36.0
https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux-aarch64.tar.gz