### PR TITLE
chore: remove dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    commit-message:
-      prefix: "chore(deps)"


### PR DESCRIPTION
Removes `.github/dependabot.yml` to protect against today's supply-chain attacks targeting Dependabot-managed dependencies.