### PR TITLE
docs: add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Agentic Coding Guide
+
+This file provides guidance for AI coding agents working in this repository.
+
+## Repository Purpose
+
+`setup-geckodriver` is a GitHub Action that downloads and installs geckodriver (the WebDriver implementation for Firefox) on GitHub Actions runners.
+
+## Commands
+
+> ⚠️ This repository uses an **older toolchain** (Jest + ESLint/Prettier + yarn) compared to other browser-actions repos.
+
+```bash
+yarn install          # install dependencies
+yarn lint             # lint with ESLint
+yarn lint:fix         # lint with auto-fix
+yarn test             # run all unit tests with Jest
+yarn build            # compile TypeScript → dist/index.js
+yarn package          # copy action.yml + README.md into dist/
+```
+
+## Project Layout
+
+```
+src/
+  index.ts            # action entry point: reads inputs, downloads and installs geckodriver
+  platform.ts         # OS/arch detection → Platform struct
+  Installer.ts        # Installer interface + base class
+  InstallerFactory.ts # factory that returns the right installer for the current platform
+__test__/
+  InstallerFactory.test.ts  # Jest unit tests for installer factory
+action.yml            # action metadata: inputs, outputs
+jest.config.js        # Jest configuration
+```
+
+## Architecture
+
+`InstallerFactory.ts` selects a platform-specific installer based on OS and architecture. The installer fetches the geckodriver release list from the GitHub Releases API, resolves the requested version, downloads the archive, extracts it, and adds the binary to `PATH`.
+
+The `token` input is passed to the GitHub API to avoid rate limiting during release list fetching.
+
+## Testing
+
+Tests live in `__test__/` and use [Jest](https://jestjs.io/).
+
+- Run `yarn test` (not `pnpm test`).
+- Tests mock GitHub API calls.
+
+## Conventions
+
+- **TypeScript** — all types must be explicit; avoid `any`.
+- **Linter:** ESLint with Prettier (not Biome — this repo predates the org-wide Biome adoption).
+- **Conventional Commits** are required for all commits (`feat:`, `fix:`, `chore:`, etc.).
+- **Never commit `dist/`** — it is built by CI and deployed to the `latest` branch on release.
+- The `action.yml` `main` field points to `index.js` inside `dist/`, not the TypeScript source.
+
+> When modernising this repo (switching to pnpm/Biome/Vitest), do so as a dedicated chore commit rather than mixing it with feature or fix changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to setup-geckodriver
+
+Thank you for your interest in contributing!
+
+## Development Setup
+
+**Prerequisites:** Node.js ≥ 24, [pnpm](https://pnpm.io/)
+
+```bash
+# Install dependencies
+pnpm install
+```
+
+## Development Workflow
+
+```bash
+# Lint (CI mode, no auto-fix)
+pnpm lint
+
+# Lint with auto-fix
+pnpm lint:fix
+
+# Run unit tests
+pnpm test
+
+# Run tests with verbose output
+pnpm test -- --reporter=verbose
+
+# Run a single test file
+npx vitest run __test__/<file>.test.ts
+
+# Build (compiles TypeScript → dist/index.js via @vercel/ncc)
+pnpm build
+
+# Package (copies action.yml + README.md into dist/)
+pnpm package
+```
+
+## Submitting Changes
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes with tests where applicable.
+3. Run `pnpm lint` and `pnpm test` to verify everything passes.
+4. Open a pull request against `master`.
+
+**Important:** All commit messages must follow [Conventional Commits][] — this is required for the automated release process to correctly determine version bumps and generate changelog entries.
+
+Examples:
+- `fix: handle rate limit errors from GitHub API`
+- `feat: add geckodriver-path output`
+- `chore: update dependencies`
+
+## Release Process
+
+Releases are automated with [Release Please](https://github.com/googleapis/release-please):
+
+1. Merge changes to `master` following Conventional Commits.
+2. Release Please opens or updates a release PR with version bumps and changelog updates.
+3. Squash and merge the release PR.
+4. CI builds `dist/`, pushes it to the `latest` branch, and creates signed `vX` and `vX.Y.Z` tags.
+
+> **Note:** Never commit generated `dist/` files to the source branch — they are built and published automatically by CI.
+
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ steps:
   - run: geckodriver --version
 ```
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, workflow, and release process.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

This PR adds two documentation files to help both human contributors and AI coding agents:

- **`CONTRIBUTING.md`** — development setup, workflow commands (`lint`, `test`, `build`, `package`), code style (Biome), PR guidelines, Conventional Commits requirement, and the release process. The README's inline contributing/release section is replaced with a link to this file.
- **`AGENTS.md`** — agentic coding guide covering commands cheatsheet, project layout, architecture overview, testing guidance, and key conventions (never commit `dist/`, strict TypeScript, etc.).