### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: ueokande


### PR DESCRIPTION
Add `.github/FUNDING.yml` to enable the GitHub Sponsor button on the repository.

```yaml
github: ueokande
```